### PR TITLE
docker-compose with .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+IMAGE=phwinter/obfs4-bridge
+# Required
+EMAIL=
+OR_PORT=
+PT_PORT=
+# Optional
+VERSION=

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,5 @@ build:
 
 .PHONY: deploy
 deploy:
-	@[ "${OR_PORT}" ] || ( echo "Env var OR_PORT is not set."; exit 1 )
-	@[ "${PT_PORT}" ] || ( echo "Env var PT_PORT is not set."; exit 1 )
-	@[ "${EMAIL}" ] || ( echo "Env var EMAIL is not set."; exit 1 )
-	@docker run \
-		--detach \
-		--env "OR_PORT=$(OR_PORT)" \
-		--env "PT_PORT=$(PT_PORT)" \
-		--env "EMAIL=$(EMAIL)" \
-		--publish "$(OR_PORT)":"$(OR_PORT)" \
-		--publish "$(PT_PORT)":"$(PT_PORT)" \
-		--restart unless-stopped \
-		--volume tor-datadir-$(OR_PORT)-$(PT_PORT):/var/lib/tor \
-		$(IMAGE):latest
+	docker-compose up -d obfs4-bridge
 	@echo "Make sure that port $(OR_PORT) and $(PT_PORT) are forwarded in your firewall."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+# This file is just ment to be used to speed up the deploy phase.
+#
+# In order to avoid that the user has to stop the container, remove it and start
+# it again with docker-compose is just needed the following command:
+#   docker-compose up -d obfs4-bridge
+#
+# Pulling the image can be done as follow:
+#   docker-compose pull obfs4-bridge
+
+version: "3.7"
+services:
+  obfs4-bridge:
+    # Uses latest image version if VERSION is unset or empty.
+    image: ${IMAGE}:${VERSION:-latest}
+    environment:
+      # Exits with an error message if OR_PORT is unset or empty.
+      - OR_PORT=${OR_PORT:?Env var OR_PORT is not set.}
+      # Exits with an error message if PT_PORT is unset or empty.
+      - PT_PORT=${PT_PORT:?Env var PT_PORT is not set.}
+      # Exits with an error message if EMAIL is unset or empty.
+      - EMAIL=${EMAIL:?Env var EMAIL is not set.}
+    volumes:
+      - data:/var/lib/tor
+    ports:
+      - ${OR_PORT}:${OR_PORT}
+      - ${PT_PORT}:${PT_PORT}
+    restart: unless-stopped
+
+volumes:
+  data:
+    name: tor-datadir-${OR_PORT}-${PT_PORT}


### PR DESCRIPTION
 I would like to propose to you few changes for the deploy. I made some changes in order to use docker-compose for the deployment.

Using docker-compose makes easier the deploying once there is a new image available. This is possible, after pulling the new image which can be done even using docker-compose pull, just doing: docker-compose up -d obfs4-bridge which is part of make deploy. In such way there is no need to stop the container, remove it and then deploy it again, which it takes three steps.

I'm not only quite sure about .env file which in case can be easily replaced by the current bridge.sh.