### PR TITLE
Test script and jobs for test and deploy.

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
 IMAGE=thymbahutymba/obfs4-bridge
-VERSION=0.4.2.6

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+IMAGE=thymbahutymba/obfs4-bridge
+VERSION=0.4.2.6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,8 @@
 name: 'Test and deploy obfs4-bridge docker image.'
 
-# Enable the test for each branch in the repository.
-on: [push]
-
-#on:
-#  # With pushing of new environment file containing tor version will trigger the
-#  # test and deploy
-#  push:
-#    branches:
-#      - master
-# Not sure about it!
-#  pull_request:
-#    branches:
-#      - master
+on:
+  repository_dispatch:
+    types: new-release
 
 # This variables are required in order to start the container and have the
 # bootstrap phase succeed.
@@ -30,7 +20,6 @@ jobs:
       - name: Source environmental variables from file
         run: |
           cat .env | grep IMAGE= | head -n 1 | sed "s/IMAGE=//" > IMAGE
-          cat .env | grep VERSION= | head -n 1 | sed "s/VERSION=//" > VERSION
 
       # If the multiarch patch will be merged, this can be extended for test
       # every images; otherwise can be set up one job for each architecture.
@@ -60,9 +49,8 @@ jobs:
       - name: Source and set environmental variables.
         run: |
           cat .env | grep IMAGE= | head -n 1 | sed "s/IMAGE=//" > IMAGE
-          cat .env | grep VERSION= | head -n 1 | sed "s/VERSION=//" > VERSION
           echo "::set-env name=IMAGE::$(cat IMAGE)"
-          echo "::set-env name=VERSION::$(cat VERSION)"
+          echo "::set-env name=VERSION::${{ github.event.client_payload.version }}"
       
       - name: Docker login
         run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,76 @@
+name: 'Test and deploy obfs4-bridge docker image.'
+
+# Enable the test for each branch in the repository.
+on: [push]
+
+#on:
+#  # With pushing of new environment file containing tor version will trigger the
+#  # test and deploy
+#  push:
+#    branches:
+#      - master
+# Not sure about it!
+#  pull_request:
+#    branches:
+#      - master
+
+# This variables are required in order to start the container and have the
+# bootstrap phase succeed.
+env:
+  OR_PORT: 1050
+  PT_PORT: 1051
+  EMAIL: testing_bridge@email.org
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Source environmental variables from file
+        run: |
+          cat .env | grep IMAGE= | head -n 1 | sed "s/IMAGE=//" > IMAGE
+          cat .env | grep VERSION= | head -n 1 | sed "s/VERSION=//" > VERSION
+
+      # If the multiarch patch will be merged, this can be extended for test
+      # every images; otherwise can be set up one job for each architecture.
+      - name: Build obfs4-bridge image
+        run: docker build -f Dockerfile -t $(cat IMAGE) .
+
+      # Starts the container with random pots and invalid email, it is required
+      # in order to test the bootstrap phase.
+      - name: Start container and copy test file into
+        run: |
+          docker run -d --env "OR_PORT=${OR_PORT}" --env "PT_PORT=${PT_PORT}" --env "EMAIL=${EMAIL}" --name testing $(cat IMAGE)
+          docker cp test.sh testing:/test.sh
+      - name: Run test
+        run: docker exec testing bash /test.sh
+  
+  deploy:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Actually is here that the variables are set as environmental in order
+      # to be available for the Makefile.
+      # This can be used also in the test job which allows to replace $(cat VAR)
+      # into simple ${VAR}
+      - name: Source and set environmental variables.
+        run: |
+          cat .env | grep IMAGE= | head -n 1 | sed "s/IMAGE=//" > IMAGE
+          cat .env | grep VERSION= | head -n 1 | sed "s/VERSION=//" > VERSION
+          echo "::set-env name=IMAGE::$(cat IMAGE)"
+          echo "::set-env name=VERSION::$(cat VERSION)"
+      
+      - name: Docker login
+        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build
+        run: make build
+
+      - name: Release
+        run: |
+          make tag
+          make release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+release_date.txt

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
-IMAGE=phwinter/obfs4-bridge
+#IMAGE=phwinter/obfs4-bridge
 
 .PHONY: tag
 tag:
 	@[ "${VERSION}" ] || ( echo "Env var VERSION is not set."; exit 1 )
 	docker tag $(IMAGE) $(IMAGE):$(VERSION)
-	docker tag $(IMAGE) $(IMAGE):latest
+	#docker tag $(IMAGE) $(IMAGE):latest
 
 .PHONY: release
 release:
 	@[ "${VERSION}" ] || ( echo "Env var VERSION is not set."; exit 1 )
 	docker push $(IMAGE):$(VERSION)
-	docker push $(IMAGE):latest
+	#docker push $(IMAGE):latest
 
 .PHONY: build
 build:

--- a/check_and_dispatch.sh
+++ b/check_and_dispatch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+if [ ! "${GITHUB_TOKEN}" ];
+then
+	echo "GITHUB_TOKEN variable needs to be defined before run the script"
+	exit 1
+fi
+
+RELEASE_FILE=/tmp/InRelease
+
+# This variables can be put all into .env file maybe changin their name.
+OWNER=$(grep "IMAGE=" .env | sed "s/IMAGE=//" | sed "s/\/.*//")
+REPO=docker-obfs4-bridge
+
+# Verifying the signature of the message
+wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import 2> /dev/null
+wget -qP /tmp https://deb.torproject.org/torproject.org/dists/stable/InRelease
+gpg --verify ${RELEASE_FILE} 2> /dev/null
+
+if [ ! $? ];
+then
+	echo "Signature verification failed."
+	exit 1
+fi;
+
+RELEASE_DATE=$(grep "Date:" ${RELEASE_FILE} | sed "s/Date: //")
+RELEASE_DATE_SECS=$(date -d "${RELEASE_DATE}" "+%s")
+
+if [ -f "release_date.txt" ];
+then
+    LAST_RELEASE_DATE=$(date -d "$(cat release_date.txt)" "+%s")
+else
+    LAST_RELEASE_DATE=0
+fi
+
+if [ ${RELEASE_DATE_SECS} -le ${LAST_RELEASE_DATE} ];
+then
+	echo "The last version was already built and deployed."
+	exit 0
+fi
+
+VERSION=$( \
+	wget -qO- https://deb.torproject.org/torproject.org/dists/stable/main/binary-amd64/Packages | \
+	grep -A1 "^Package: tor$" | \
+	grep "^Version:" | \
+	sed "s/Version: //" | sed "s/~.*//")
+
+# Trigger github in order to test and build the new docker image.
+curl \
+	-H "Accept: application/vnd.github.everest-preview+json" \
+	-H "Authorization: token ${GITHUB_TOKEN}" \
+	--request POST \
+	--data '{"event_type": "new-release", "client_payload": {"version": "'"${VERSION}"'"}}' \
+	https://api.github.com/repos/${OWNER}/${REPO}/dispatches
+
+echo "Writing new release date to file."
+echo ${RELEASE_DATE} > release_date.txt

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+# Tries after which the test fails.
+MAX_TRIES=3
+
+# Bootstrap requires time then the sleeping time between attemps should be long.
+SLEEP_TIME=5s
+
+TOR_LOG=/var/log/tor/log
+
+check_for ()
+{
+		echo -n "[    ] ${1}"
+		for i in $(seq 1 ${MAX_TRIES});
+		do
+				if grep -q "${1}" ${TOR_LOG}; then
+						echo -e "\r[${GREEN} ok ${RESET}] ${1}"
+						break
+				fi
+
+				if [[ $i == ${MAX_TRIES} ]]; then
+						echo -e "\r[${RED} failed ${RESET}] ${1}"
+						echo -e "\nTest failed."
+						exit 1
+				fi
+
+				sleep ${SLEEP_TIME}
+		done
+}
+
+check_for "Bootstrapped 0%"
+check_for "Bootstrapped 100%"
+
+echo -e "\nTest passed."
+exit 0

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ RESET='\033[0m'
 MAX_TRIES=3
 
 # Bootstrap requires time then the sleeping time between attemps should be long.
-SLEEP_TIME=5s
+SLEEP_TIME=10s
 
 TOR_LOG=/var/log/tor/log
 

--- a/test.sh
+++ b/test.sh
@@ -24,7 +24,7 @@ check_for ()
 
 				if [[ $i == ${MAX_TRIES} ]]; then
 						echo -e "\r[${RED} failed ${RESET}] ${1}"
-						echo -e "\nTest failed."
+						echo -e "\nTest of the bootstrap phase failed."
 						exit 1
 				fi
 
@@ -35,5 +35,14 @@ check_for ()
 check_for "Bootstrapped 0%"
 check_for "Bootstrapped 100%"
 
-echo -e "\nTest passed."
+# Test get-bridge-line script
+get-bridge-line | grep -qE "obfs4 ([0-9]{1,3}(\.|:)){4}[0-9]{1,5} [a-zA-Z0-9]{40} cert=[a-zA-Z0-9,\/]{70} iat-mode=0"
+
+if [ ! $? ];
+then
+	echo "Test of the get-bridge-line script failed."
+	exit 1
+fi
+
+echo -e "\nTests passed."
 exit 0


### PR DESCRIPTION
I set up everything in order to test the bootstrap of the docker image and deploy it on docker hub. Some changes are required in order to set it work into different repository.

There are a lot of comments in the files that I've added because there is more that one way in which such things can be done, let's discuss it.

I just would like to point out that in order to trigger the workflow is required to update the .env file with the new tor version. I did not yet figured out how to trigger it automatically with some "external request".

**EDIT:**
With the last commit a systemd timer can be set up in order to run the script periodically in order to keep update the docker image. There is only one issue: the VERSION variable in the .env file should be guessed somehow; in the [Release](https://deb.torproject.org/torproject.org/dists/stable/Release) file there is not such information.