### PR TITLE
CI/CD pipeline for multiarch docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,91 @@
+name: 'Test and deploy obfs4-bridge docker image.'
+
+on:
+  repository_dispatch:
+    types: new-release
+
+# This variables are required in order to start the container and have the
+# bootstrap phase succeed.
+env:
+  IMAGE: thymbahutymba/obfs4-bridge
+  OR_PORT: 1050
+  PT_PORT: 1051
+  EMAIL: testing_bridge@email.org
+  DOCKER_CLI_EXPERIMENTAL: enabled
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      #- name: Enable experimental features
+      #  run: | 
+      #    echo '{ "experimental": true }' | sudo tee -a /etc/docker/daemon.json
+
+      - name: Docker login
+        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Source and set environmental variables.
+        run: |
+          echo "::set-env name=amd64_version::${{ github.event.client_payload.amd64 }}"
+          echo "::set-env name=arm64_version::${{ github.event.client_payload.arm64 }}"
+          echo "::set-env name=arm_version::${{ github.event.client_payload.arm }}"
+
+      # The two following steps are mutually exclusive, only one of them is executed.
+      - name: Tor version for amd64 is unchanged
+        if: github.event.client_payload.amd64 == '-1'
+        run: | 
+          docker pull ${IMAGE}:amd64-latest
+
+      - name: New tor version for amd64. Build, test and deploy new image
+        if: github.event.client_payload.amd64 != '-1'
+        run: |
+          make build ARCH=amd64
+          docker run -d --env "OR_PORT=${OR_PORT}" --env "PT_PORT=${PT_PORT}" --env "EMAIL=${EMAIL}" --name test_amd64 ${IMAGE}:amd64-${amd64_version}
+          docker cp test.sh test_amd64:/test.sh
+          docker exec test_amd64 bash /test.sh
+
+          # Since we reach this point the new amd64 image passed the test and 
+          # can be released.
+          make release-version ARCH=amd64
+
+      # The two following steps are mutually exclusive, only one of them is executed. 
+      - name: Tor version for arm64 is unchanged
+        if: github.event.client_payload.arm64 == '-1'
+        run: | 
+          docker pull ${IMAGE}:arm64-latest
+
+      - name: New tor version for arm64. Build, test and deploy new image
+        if: github.event.client_payload.arm64 != '-1'
+        run: |
+          make build ARCH=arm64
+          docker run -d --env "OR_PORT=${OR_PORT}" --env "PT_PORT=${PT_PORT}" --env "EMAIL=${EMAIL}" --name test_arm64 ${IMAGE}:arm64-${arm64_version}
+          docker cp test.sh test_arm64:/test.sh
+          docker exec test_arm64 bash /test.sh
+
+          # Since we reach this point the new amd64 image passed the test and 
+          # can be released.
+          make release-version ARCH=arm64
+
+      # The two following steps are mutually exclusive, only one of them is executed. 
+      - name: Tor version for arm is unchanged
+        if: github.event.client_payload.arm == '-1'
+        run: | 
+          docker pull ${IMAGE}:arm-latest
+
+      - name: New tor version for arm. Build, test and deploy new image
+        if: github.event.client_payload.arm != '-1'
+        run: |
+          make build ARCH=arm
+          docker run -d --env "OR_PORT=${OR_PORT}" --env "PT_PORT=${PT_PORT}" --env "EMAIL=${EMAIL}" --name test_arm ${IMAGE}:arm-${arm64_version}
+          docker cp test.sh test_arm:/test.sh
+          docker exec test_arm bash /test.sh
+
+          # Since we reach this point the new amd64 image passed the test and 
+          # can be released.
+          make release-version ARCH=arm
+
+      - name: Release the new manifest for latest images
+        run: make release-manifest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
-      #- name: Enable experimental features
-      #  run: | 
-      #    echo '{ "experimental": true }' | sudo tee -a /etc/docker/daemon.json
 
       - name: Docker login
         run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
@@ -34,10 +30,10 @@ jobs:
           echo "::set-env name=arm_version::${{ github.event.client_payload.arm }}"
 
       # The two following steps are mutually exclusive, only one of them is executed.
-      - name: Tor version for amd64 is unchanged
-        if: github.event.client_payload.amd64 == '-1'
-        run: | 
-          docker pull ${IMAGE}:amd64-latest
+      #- name: Tor version for amd64 is unchanged
+      #  if: github.event.client_payload.amd64 == '-1'
+      #  run: | 
+      #    docker pull ${IMAGE}:amd64-latest
 
       - name: New tor version for amd64. Build, test and deploy new image
         if: github.event.client_payload.amd64 != '-1'
@@ -52,10 +48,10 @@ jobs:
           make release-version ARCH=amd64
 
       # The two following steps are mutually exclusive, only one of them is executed. 
-      - name: Tor version for arm64 is unchanged
-        if: github.event.client_payload.arm64 == '-1'
-        run: | 
-          docker pull ${IMAGE}:arm64-latest
+      #- name: Tor version for arm64 is unchanged
+      #  if: github.event.client_payload.arm64 == '-1'
+      #  run: | 
+      #    docker pull ${IMAGE}:arm64-latest
 
       - name: New tor version for arm64. Build, test and deploy new image
         if: github.event.client_payload.arm64 != '-1'
@@ -70,10 +66,10 @@ jobs:
           make release-version ARCH=arm64
 
       # The two following steps are mutually exclusive, only one of them is executed. 
-      - name: Tor version for arm is unchanged
-        if: github.event.client_payload.arm == '-1'
-        run: | 
-          docker pull ${IMAGE}:arm-latest
+      #- name: Tor version for arm is unchanged
+      #  if: github.event.client_payload.arm == '-1'
+      #  run: | 
+      #    docker pull ${IMAGE}:arm-latest
 
       - name: New tor version for arm. Build, test and deploy new image
         if: github.event.client_payload.arm != '-1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,15 +25,9 @@ jobs:
 
       - name: Source and set environmental variables.
         run: |
-          echo "::set-env name=amd64_version::${{ github.event.client_payload.amd64 }}"
-          echo "::set-env name=arm64_version::${{ github.event.client_payload.arm64 }}"
-          echo "::set-env name=arm_version::${{ github.event.client_payload.arm }}"
-
-      # The two following steps are mutually exclusive, only one of them is executed.
-      #- name: Tor version for amd64 is unchanged
-      #  if: github.event.client_payload.amd64 == '-1'
-      #  run: | 
-      #    docker pull ${IMAGE}:amd64-latest
+          echo "amd64_version=${{ github.event.client_payload.amd64 }}" >> $GITHUB_ENV
+          echo "arm64_version=${{ github.event.client_payload.arm64 }}" >> $GITHUB_ENV
+          echo "arm_version=${{ github.event.client_payload.arm }}"     >> $GITHUB_ENV
 
       - name: New tor version for amd64. Build, test and deploy new image
         if: github.event.client_payload.amd64 != '-1'
@@ -47,12 +41,6 @@ jobs:
           # can be released.
           make release-version ARCH=amd64
 
-      # The two following steps are mutually exclusive, only one of them is executed. 
-      #- name: Tor version for arm64 is unchanged
-      #  if: github.event.client_payload.arm64 == '-1'
-      #  run: | 
-      #    docker pull ${IMAGE}:arm64-latest
-
       - name: New tor version for arm64. Build, test and deploy new image
         if: github.event.client_payload.arm64 != '-1'
         run: |
@@ -64,12 +52,6 @@ jobs:
           # Since we reach this point the new amd64 image passed the test and 
           # can be released.
           make release-version ARCH=arm64
-
-      # The two following steps are mutually exclusive, only one of them is executed. 
-      #- name: Tor version for arm is unchanged
-      #  if: github.event.client_payload.arm == '-1'
-      #  run: | 
-      #    docker pull ${IMAGE}:arm-latest
 
       - name: New tor version for arm. Build, test and deploy new image
         if: github.event.client_payload.arm != '-1'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Dockerfile
+.env

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,0 +1,2 @@
+# Base docker image
+FROM debian:buster-slim

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,5 +1,5 @@
 FROM multiarch/qemu-user-static:x86_64-arm as qemu
 
 # Base docker image
-FROM arm32v7/debian:buster-slim
+FROM arm32v7/debian:bullseye-slim
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,5 @@
+FROM multiarch/qemu-user-static:x86_64-arm as qemu
+
+# Base docker image
+FROM arm32v7/debian:buster-slim
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,5 @@
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+
+# Base docker image
+FROM arm64v8/debian:buster-slim
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -13,11 +13,11 @@ RUN apt-get update && apt-get install -y \
 RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
 RUN gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
 
-RUN if [ "$(uname -m)" =~ "armv7" ]; \
+RUN bash -c 'if [[ ! "$(uname -m)" =~ "armv7" ]]; \
     then \
         printf "deb https://deb.torproject.org/torproject.org stable main\n" >> \
             /etc/apt/sources.list.d/tor.list; \
-    fi
+    fi'
 
 # Install remaining dependencies.
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -13,7 +13,11 @@ RUN apt-get update && apt-get install -y \
 RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
 RUN gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
 
-RUN printf "deb https://deb.torproject.org/torproject.org stable main\n" >> /etc/apt/sources.list.d/tor.list
+RUN if [ "$(uname -m)" =~ "armv7" ]; \
+    then \
+        printf "deb https://deb.torproject.org/torproject.org stable main\n" >> \
+            /etc/apt/sources.list.d/tor.list; \
+    fi
 
 # Install remaining dependencies.
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -1,11 +1,8 @@
-# Base docker image
-FROM debian:stable-slim
-
 LABEL maintainer="Philipp Winter <phw@torproject.org>"
 
 # Install dependencies to add Tor's repository.
 RUN apt-get update && apt-get install -y \
-    curl \
+    wget \
     gpg \
     gpg-agent \
     ca-certificates \
@@ -13,10 +10,10 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends
 
 # See: <https://2019.www.torproject.org/docs/debian.html.en>
-RUN curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
+RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
 RUN gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
 
-RUN printf "deb https://deb.torproject.org/torproject.org stable main\n" >> /etc/apt/sources.list.d/tor
+RUN printf "deb https://deb.torproject.org/torproject.org stable main\n" >> /etc/apt/sources.list.d/tor.list
 
 # Install remaining dependencies.
 RUN apt-get update && apt-get install -y \

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,44 @@
-IMAGE=phwinter/obfs4-bridge
+IMAGE=thymbahutymba/obfs4-bridge
 
-.PHONY: tag
-tag:
-	@[ "${VERSION}" ] || ( echo "Env var VERSION is not set."; exit 1 )
-	docker tag $(IMAGE) $(IMAGE):$(VERSION)
-	docker tag $(IMAGE) $(IMAGE):latest
+# The release of a new version of the image makes it the latest
+.PHONY: release-version
+release-version:
+	@[ "$(ARCH)" ] || ( echo "Env var ARCH is not set."; exit 1 )
+	@[ "$($(ARCH)_version)" ] || ( echo "Env var $($(ARCH)_version) is not set."; exit 1 )
 
-.PHONY: release
-release:
-	@[ "${VERSION}" ] || ( echo "Env var VERSION is not set."; exit 1 )
-	docker push $(IMAGE):$(VERSION)
-	docker push $(IMAGE):latest
+	docker tag $(IMAGE):$(ARCH)-$($(ARCH)_version) $(IMAGE):$(ARCH)-latest
+	docker push $(IMAGE):$(ARCH)-$($(ARCH)_version)
+	docker push $(IMAGE):$(ARCH)-latest
+
+.PHONY: release-manifest
+release-manifest:
+	docker manifest create $(IMAGE):latest \
+		$(IMAGE):amd64-latest \
+		$(IMAGE):arm64-latest \
+		$(IMAGE):arm-latest
+
+	docker manifest push --purge $(IMAGE):latest
 
 .PHONY: build
 build:
-	docker build -t $(IMAGE) .
+	@[ "$(ARCH)" ] || ( echo "Env var ARCH is not set."; exit 1 )
+	@[ "$($(ARCH)_version)" ] || ( echo "Env var $(ARCH)_version is not set."; exit 1 )
+
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+	cat Dockerfile.$(ARCH) Dockerfile.common > Dockerfile
+	docker build -t $(IMAGE):$(ARCH)-$($(ARCH)_version) .
 
 .PHONY: deploy
 deploy:
 	docker-compose up -d obfs4-bridge
 	@echo "Make sure that port $(OR_PORT) and $(PT_PORT) are forwarded in your firewall."
+
+.PHONY: install
+install:
+	install -d /usr/local/lib/systemd/system
+	install -m 644 ./systemd/docker-obfs4-bridge.service /usr/local/lib/systemd/system
+	install -m 644 ./systemd/docker-obfs4-bridge.timer /usr/local/lib/systemd/system
+	install -m 744 release-new-image /usr/local/bin
+
+	@echo -e "\nExecute systemctl enable --now docker-obfs4-bridge.timer in order to enable and start the timer"

--- a/release-new-image
+++ b/release-new-image
@@ -13,8 +13,14 @@ fi
 JSON=$(wget -qO- https://registry.hub.docker.com/v2/repositories/${OWNER}/${IMAGE}/tags)
 ARCHS=("amd64" "arm64" "arm")
 
-# Version greater or equal 
-version_ge() {
+# Version greater
+version_gt() {
+    # Whether the image is already at the latest version no update is required
+    if [ "$1" = "$2" ];
+    then
+        return 1
+    fi
+
     [  "$1" = "$(echo -e "$1\n$2" | sort -V | tail -n1)" ]
 }
 
@@ -33,7 +39,7 @@ new_version_for () {
     # Get the digest of all images in latest manifest
     DIGEST=$(jq -r '.results[] | select(.name=="latest") | .images[] | select(.architecture=="'$1'") | .digest' <<< ${JSON})
     NAME=$(jq -r '.results[] | select(.images[].digest=="'"${DIGEST}"'" and select(.name | test("(-[0-9])"))) | .name' <<< ${JSON})
-    DOCKER_VERSION=$(sed 's/.*-//' <<< ${NAME})
+    DOCKER_VERSION=$(sed 's/'$1'-//' <<< ${NAME})
 
     case $1 in
         "arm") ARCH='armhf' ;;
@@ -46,7 +52,7 @@ new_version_for () {
         grep "^Version:" | \
         sed "s/Version: //" | sed "s/~.*//")
 
-	if version_ge ${LATEST_VERSION} ${DOCKER_VERSION};
+	if version_gt ${LATEST_VERSION} ${DOCKER_VERSION};
 	then
     	# Return latest version to caller
     	eval "$2='${LATEST_VERSION}'"

--- a/release-new-image
+++ b/release-new-image
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# This variables can be put all into .env file maybe changin their name.
+OWNER=thymbahutymba
+IMAGE=obfs4-bridge
+
+if [ ! "${GITHUB_TOKEN}" ];
+then
+	echo "GITHUB_TOKEN variable needs to be defined before run the script"
+	exit 1
+fi
+
+JSON=$(wget -qO- https://registry.hub.docker.com/v2/repositories/${OWNER}/${IMAGE}/tags)
+ARCHS=("amd64" "arm64" "arm")
+
+# Version greater or equal 
+version_ge() {
+    [  "$1" = "$(echo -e "$1\n$2" | sort -V | tail -n1)" ]
+}
+
+# Check if there is new version available for given architecture
+new_version_for () {
+    if [ $# -ne 2 ];
+    then
+        echo "check_new_version_for requires the arch and the variable to return the latest version."
+        exit 1
+    elif [[ ! ${ARCHS[@]} =~ $1 ]];
+    then
+        echo "Architecture "$1" not supported. [" ${ARCHS[@]} "]"
+        exit 1
+    fi
+
+    # Get the digest of all images in latest manifest
+    DIGEST=$(jq -r '.results[] | select(.name=="latest") | .images[] | select(.architecture=="'$1'") | .digest' <<< ${JSON})
+    NAME=$(jq -r '.results[] | select(.images[].digest=="'"${DIGEST}"'" and select(.name | test("(-[0-9])"))) | .name' <<< ${JSON})
+    DOCKER_VERSION=$(sed 's/.*-//' <<< ${NAME})
+
+    case $1 in
+        "arm") ARCH='armhf' ;;
+        *) ARCH=$1 ;;
+    esac
+
+    LATEST_VERSION=$( \
+        wget -qO- https://deb.torproject.org/torproject.org/dists/stable/main/binary-${ARCH}/Packages | \
+        grep -A1 "^Package: tor$" | \
+        grep "^Version:" | \
+        sed "s/Version: //" | sed "s/~.*//")
+
+	if version_ge ${LATEST_VERSION} ${DOCKER_VERSION};
+	then
+    	# Return latest version to caller
+    	eval "$2='${LATEST_VERSION}'"
+	fi
+}
+
+AMD64_VERSION='-1'
+new_version_for "amd64" AMD64_VERSION
+
+ARM64_VERSION='-1'
+new_version_for "arm64" ARM64_VERSION
+
+ARM_VERSION='-1'
+new_version_for "arm" ARM_VERSION
+
+if [[ ${ARM64_VERSION} = '-1' && ${ARM64_VERSION} = '-1' && ${ARM_VERSION} = '-1' ]];
+then
+	echo "The docker images are already at the latest version."
+	exit 0
+fi
+
+# Trigger github in order to test and build the new docker image.
+data=$(cat << EOF
+{
+	"event_type": "new-release", 
+	"client_payload": {
+		"amd64": "${AMD64_VERSION}",
+		"arm64": "${ARM64_VERSION}",
+		"arm": "${ARM_VERSION}"
+	}
+}
+EOF
+)
+
+#echo ${data}
+
+curl \
+	-H "Accept: application/vnd.github.everest-preview+json" \
+	-H "Authorization: token ${GITHUB_TOKEN}" \
+	--request POST \
+	--data "${data}" \
+    https://api.github.com/repos/${OWNER}/docker-${IMAGE}/dispatches

--- a/release-new-image
+++ b/release-new-image
@@ -15,47 +15,62 @@ ARCHS=("amd64" "arm64" "arm")
 
 # Version greater
 version_gt() {
-    # Whether the image is already at the latest version no update is required
-    if [ "$1" = "$2" ];
-    then
-        return 1
-    fi
+	# Whether the image is already at the latest version no update is required
+	if [ "$1" = "$2" ];
+	then
+		return 1
+	fi
 
-    [  "$1" = "$(echo -e "$1\n$2" | sort -V | tail -n1)" ]
+	[  "$1" = "$(echo -e "$1\n$2" | sort -V | tail -n1)" ]
 }
 
 # Check if there is new version available for given architecture
 new_version_for () {
-    if [ $# -ne 2 ];
-    then
-        echo "check_new_version_for requires the arch and the variable to return the latest version."
-        exit 1
-    elif [[ ! ${ARCHS[@]} =~ $1 ]];
-    then
-        echo "Architecture "$1" not supported. [" ${ARCHS[@]} "]"
-        exit 1
-    fi
+	if [ $# -ne 2 ];
+	then
+		echo "check_new_version_for requires the arch and the variable to return the latest version."
+		exit 1
+	elif [[ ! ${ARCHS[@]} =~ $1 ]];
+	then
+		echo "Architecture "$1" not supported. [" ${ARCHS[@]} "]"
+		exit 1
+	fi
 
-    # Get the digest of all images in latest manifest
-    DIGEST=$(jq -r '.results[] | select(.name=="latest") | .images[] | select(.architecture=="'$1'") | .digest' <<< ${JSON})
-    NAME=$(jq -r '.results[] | select(.images[].digest=="'"${DIGEST}"'" and select(.name | test("(-[0-9])"))) | .name' <<< ${JSON})
-    DOCKER_VERSION=$(sed 's/'$1'-//' <<< ${NAME})
+	# Get the digest of all images in latest manifest
+	DIGEST=$(jq -r '.results[] | select(.name=="latest") | .images[] | select(.architecture=="'$1'") | .digest' <<< ${JSON})
+	NAME=$(jq -r '.results[] | select(.images[].digest=="'"${DIGEST}"'" and select(.name | test("(-[0-9])"))) | .name' <<< ${JSON})
+	DOCKER_VERSION=$(sed 's/'$1'-//' <<< ${NAME})
 
-    case $1 in
-        "arm") ARCH='armhf' ;;
-        *) ARCH=$1 ;;
-    esac
+	: "
+	Since tor 0.4.3.x, the binary Debian packages on deb.torproject.org  will 
+	not anymore provided. Therefore, the debian repository has been chosen, in 
+	order to continue to have docker images for arm architecture.
 
-    LATEST_VERSION=$( \
-        wget -qO- https://deb.torproject.org/torproject.org/dists/stable/main/binary-${ARCH}/Packages | \
-        grep -A1 "^Package: tor$" | \
-        grep "^Version:" | \
-        sed "s/Version: //" | sed "s/~.*//")
+	Moreover, in order to detect whether newer tor version is available, apt is 
+	used. Finally, in order to keep the script independent from the platform in
+	which is executed, docker is used to detect for newer version. 
+	"
+	if [ "$1" = "arm" ];
+	then
+		docker run --rm --privileged multiarch/qemu-user-static --reset -p yes 1> /dev/null
+		LATEST_VERSION=$(docker run --rm -it arm32v7/debian:bullseye-slim bash -c \
+			"apt-get update 1> /dev/null && \
+			apt-cache show tor" | \
+			grep '^Version:' | \
+			sed 's/Version: //' | \
+			tr -d '\r')
+	else
+		LATEST_VERSION=$( \
+			wget -qO- https://deb.torproject.org/torproject.org/dists/stable/main/binary-$1/Packages | \
+			grep -A1 "^Package: tor$" | \
+			grep "^Version:" | \
+			sed "s/Version: //" | sed "s/~.*//")
+	fi
 
 	if version_gt ${LATEST_VERSION} ${DOCKER_VERSION};
 	then
-    	# Return latest version to caller
-    	eval "$2='${LATEST_VERSION}'"
+		# Return latest version to caller
+		eval "$2='${LATEST_VERSION}'"
 	fi
 }
 
@@ -87,11 +102,9 @@ data=$(cat << EOF
 EOF
 )
 
-#echo ${data}
-
 curl \
 	-H "Accept: application/vnd.github.everest-preview+json" \
 	-H "Authorization: token ${GITHUB_TOKEN}" \
 	--request POST \
 	--data "${data}" \
-    https://api.github.com/repos/${OWNER}/docker-${IMAGE}/dispatches
+	https://api.github.com/repos/${OWNER}/docker-${IMAGE}/dispatches

--- a/systemd/docker-obfs4-bridge.service
+++ b/systemd/docker-obfs4-bridge.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Execute the script that allows to check and trigger the CI/CD pipeline when the new tor version is available.
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/release-new-image

--- a/systemd/docker-obfs4-bridge.timer
+++ b/systemd/docker-obfs4-bridge.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer for checking and triggering the CI/CD pipeline when the new tor version is available.
+
+[Timer]
+OnCalendar=*-*-* 12:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+# Tries after which the test fails.
+MAX_TRIES=3
+
+# Bootstrap requires time then the sleeping time between attemps should be long.
+SLEEP_TIME=20s
+
+TOR_LOG=/var/log/tor/log
+
+check_for ()
+{
+		echo -n "[    ] ${1}"
+		for i in $(seq 1 ${MAX_TRIES});
+		do
+				if grep -q "${1}" ${TOR_LOG}; then
+						echo -e "\r[${GREEN} ok ${RESET}] ${1}"
+						break
+				fi
+
+				if [[ $i == ${MAX_TRIES} ]]; then
+						echo -e "\r[${RED} failed ${RESET}] ${1}"
+						echo -e "\nTest of the bootstrap phase failed."
+						exit 1
+				fi
+
+				sleep ${SLEEP_TIME}
+		done
+}
+
+check_for "Bootstrapped 0%"
+check_for "Bootstrapped 100%"
+
+# Test get-bridge-line script
+get-bridge-line | grep -qE "obfs4 ([0-9]{1,3}(\.|:)){4}[0-9]{1,5} [a-zA-Z0-9]{40} cert=[a-zA-Z0-9,\/]{70} iat-mode=0"
+
+if [ ! $? ];
+then
+	echo "Test of the get-bridge-line script failed."
+	exit 1
+fi
+
+echo -e "\nTests passed."
+exit 0


### PR DESCRIPTION
In order to make things clear I'm proposing a new pull request that is meant to replace #4.

This patch takes into account #1 which provides the docker-obfs4-bridge images for amd64, arm64 and arm architectures.
New github workflow is proposed. This workflow is composed with just one job with many steps. The workflow allows to build the new images, run the test script and eventually release on hub.docker.com. Furthermore, systemd service and timer is provided in order to execute the release-new-image script once a day at 12:00 UTC. The release-new-image script triggers the workflow only if new tor version is detected.