### PR TITLE
Add `with_nyx` build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Base docker image
 FROM debian:stable-slim
 
+ARG with_nyx
+
 LABEL maintainer="Philipp Winter <phw@torproject.org>"
 
 # Install dependencies to add Tor's repository.
@@ -19,11 +21,15 @@ RUN gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
 RUN printf "deb https://deb.torproject.org/torproject.org stable main\n" >> /etc/apt/sources.list.d/tor
 
 # Install remaining dependencies.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     tor \
     tor-geoipdb \
-    obfs4proxy \
-    --no-install-recommends
+    obfs4proxy
+
+# Install nyx if requested
+RUN if [ -n "$with_nyx" ]; then \
+        apt-get install -y --no-install-recommends nyx; \
+    fi
 
 # Allow obfs4proxy to bind to ports < 1024.
 RUN setcap cap_net_bind_service=+ep /usr/bin/obfs4proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,14 @@ RUN apt-get update && apt-get install -y \
 # Allow obfs4proxy to bind to ports < 1024.
 RUN setcap cap_net_bind_service=+ep /usr/bin/obfs4proxy
 
-# Our torrc is generated at run-time by the script start-tor.sh.
-RUN rm /etc/tor/torrc
 RUN chown debian-tor:debian-tor /etc/tor
 RUN chown debian-tor:debian-tor /var/log/tor
+
+RUN mkdir /etc/tor/torrc.d
+RUN chown debian-tor:debian-tor /etc/tor/torrc.d
+
+COPY torrc /etc/tor
+RUN chown debian-tor:debian-tor /etc/tor/torrc
 
 COPY start-tor.sh /usr/local/bin
 RUN chmod 0755 /usr/local/bin/start-tor.sh

--- a/start-tor.sh
+++ b/start-tor.sh
@@ -9,5 +9,14 @@ ServerTransportListenAddr obfs4 0.0.0.0:${PT_PORT}
 ContactInfo ${EMAIL}
 EOF
 
+if which nyx >/dev/null 2>&1; then
+    echo "Adding configuration for Nyx connection"
+    cat > /etc/tor/torrc.d/nyx << EOF
+# Enable local access for Nyx
+ControlPort 9051
+CookieAuthentication 1
+EOF
+fi
+
 echo "Starting tor."
-tor -f /etc/tor/torrc
+exec tor -f /etc/tor/torrc

--- a/start-tor.sh
+++ b/start-tor.sh
@@ -2,27 +2,10 @@
 
 echo "Using OR_PORT=${OR_PORT}, PT_PORT=${PT_PORT}, and EMAIL=${EMAIL}."
 
-cat > /etc/tor/torrc << EOF
-RunAsDaemon 0
-# We don't need an open SOCKS port.
-SocksPort 0
-BridgeRelay 1
-# A static nickname makes it easy to identify bridges that were set up using
-# this Docker image.
-Nickname DockerObfs4Bridge
-Log notice file /var/log/tor/log
-Log notice stdout
-ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
-ExtORPort auto
-DataDirectory /var/lib/tor
-
-# The variable "OR_PORT" is replaced with the OR port.
+# Add configuration from docker-compose's environment
+cat > /etc/tor/torrc.d/env << EOF
 ORPort ${OR_PORT}
-
-# The variable "PT_PORT" is replaced with the obfs4 port.
 ServerTransportListenAddr obfs4 0.0.0.0:${PT_PORT}
-
-# The variable "EMAIL" is replaced with the operator's email address.
 ContactInfo ${EMAIL}
 EOF
 

--- a/torrc
+++ b/torrc
@@ -1,0 +1,21 @@
+RunAsDaemon 0
+
+# We don't need an open SOCKS port.
+SocksPort 0
+BridgeRelay 1
+
+# A static nickname makes it easy to identify bridges that were set up using
+# this Docker image.
+Nickname DockerObfs4Bridge
+
+Log notice file /var/log/tor/log
+Log notice stdout
+
+ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
+
+ExtORPort auto
+
+DataDirectory /var/lib/tor
+
+# Include runtime generated config
+%include /etc/tor/torrc.d/


### PR DESCRIPTION
I wanted to have [Nyx](https://nyx.torproject.org/) installed in the container to be able to monitor the bridge easily:
```bash
docker exec -it tor-bridge nyx
```